### PR TITLE
Set minimum platform to macOS 14 / iOS 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.9
 
 import PackageDescription
 
 let package = Package(
     name: "SwiftSVG",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Fix SPM platform version error: Swift2D 2.2.1 requires macOS 13.0 minimum but SwiftSVG had no platform constraint set.